### PR TITLE
Fixes netcat package name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /app
 # Run OS updates
 # create unprivileged user, create application directories, and ensure proper permissions
 # Install application dependencies
-RUN apt-get update &&  apt-get install -y --no-install-recommends  netcat git \
+RUN apt-get update &&  apt-get install -y --no-install-recommends  netcat-traditional git \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -g ${IMAGE_GID} webapp \
     && useradd -u ${IMAGE_UID} -g ${IMAGE_GID} -c 'Web app User'  --no-create-home webapp \


### PR DESCRIPTION
closes #7

Since Debian changed the netcat package name from `netcat` to `netcat-traditional`, it needs to replaced in the Dockerfile.

Source: https://packages.debian.org/buster/netcat